### PR TITLE
Migrate to satyrographos 0.0.2

### DIFF
--- a/Installer.sh
+++ b/Installer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -eux
 
-cp -f exdesign.satyh article-ja.satyh ~/.satysfi/dist/packages
+mkdir -p ~/.satysfi/dist/packages/class-exdesign
+cp -f exdesign.satyh article-ja.satyh ~/.satysfi/dist/packages/class-exdesign

--- a/Satyristes
+++ b/Satyristes
@@ -1,0 +1,22 @@
+;; For Satyrographos 0.0.2 series
+(version 0.0.2)
+
+(library
+  (name "class-exdesign")
+  (version "0.2")
+  (sources
+    ((package "article-ja.satyh" "article-ja.satyh")
+     (package "exdesign.satyh" "exdesign.satyh")))
+  (opam "satysfi-class-exdesign.opam")
+  (dependencies ()))
+
+(libraryDoc
+  (name "class-exdesign-doc")
+  (version "0.2")
+  (workingDirectory "doc")
+  (build
+    ((satysfi "manual.saty" "-o" "manual.pdf")))
+  (sources
+    ((doc "manual.pdf" "doc/manual.pdf")))
+  (opam "satysfi-class-exdesign-doc.opam")
+  (dependencies ((class-exdesign ()))))

--- a/Satyristes
+++ b/Satyristes
@@ -8,7 +8,8 @@
     ((package "article-ja.satyh" "article-ja.satyh")
      (package "exdesign.satyh" "exdesign.satyh")))
   (opam "satysfi-class-exdesign.opam")
-  (dependencies ()))
+  (dependencies ())
+  (compatibility ((satyrographos "0.0.1"))))
 
 (libraryDoc
   (name "class-exdesign-doc")

--- a/UnInstaller.sh
+++ b/UnInstaller.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 set -eux
 
-cd ~/.satysfi/dist/packages
-rm -f exdesign.satyh article-ja.satyh
+rm -rf ~/.satysfi/dist/packages/class-exdesign

--- a/article-ja.satyh
+++ b/article-ja.satyh
@@ -3,7 +3,7 @@
 %https://github.com/puripuri2100/exdesign
 %v0.2
 
-@require: exdesign
+@require: class-exdesign/exdesign
 
 module ArticleJa : sig
 

--- a/article-ja.satyh
+++ b/article-ja.satyh
@@ -3,7 +3,7 @@
 %https://github.com/puripuri2100/exdesign
 %v0.2
 
-@require: class-exdesign/exdesign
+@import: exdesign
 
 module ArticleJa : sig
 

--- a/doc/manual.saty
+++ b/doc/manual.saty
@@ -1,5 +1,5 @@
-@require: exdesign
-@require: article-ja
+@require: class-exdesign/exdesign
+@require: class-exdesign/article-ja
 @require: code
 @require: itemize
 
@@ -22,8 +22,8 @@ document (|
   +section{簡単な使用方法}<
       +p{補助パッケージを使用する際にはこのように書きます。}
         +code(`
-@require: exdesign
-@require: article-ja
+@require: class-exdesign/exdesign
+@require: class-exdesign/article-ja
 
 document (|
         title = {title;
@@ -39,7 +39,7 @@ document (|
     +p{test}
 >`
 );
-+pn{このように、\code(`@require : exdesign`);でパッケージを読み込み、補助パッケージであるarticle-ja.satyhを\code(`@require : article-ja`);で読み込みます（勿論、article-ja.satyhの置き場所によってどのコマンドを使用して読み込むかは変わりますが）。}
++pn{このように、\code(`@require : class-exdesign/exdesign`);でパッケージを読み込み、補助パッケージであるarticle-ja.satyhを\code(`@require : class-exdesign/article-ja`);で読み込みます（勿論、article-ja.satyhの置き場所によってどのコマンドを使用して読み込むかは変わりますが）。}
 
 +p{そして、\code(`document`);コマンドの引数であるレコード型に必要な値を入れていきます。}
 

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,8 @@ $ sudo ./UnInstaller.sh
 # 使い方
 
 ~~~
-@require: exdesign
-@import: article-ja
+@require: class-exdesign/exdesign
+@import: class-exdesign/article-ja
 
 document (|
         title = {title};

--- a/satysfi-class-exdesign-doc.opam
+++ b/satysfi-class-exdesign-doc.opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+name: "satysfi-class-exdesign-doc"
+version: "0.2"
+synopsis: "Documentation: A class file easy to customize with SATySFi"
+description: """Documentation: A class file easy to customize with SATySFi."""
+
+maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
+authors: "Naoki Kaneko <puripuri2100@gmail.com>"
+license: "LGPLv3"
+homepage: "https://github.com/puripuri2100/exdesign"
+bug-reports: "https://github.com/puripuri2100/exdesign/issues"
+dev-repo: "git+https://github.com/puripuri2100/exdesign.git"
+
+depends: [
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi-lib-dist"
+
+  # You may want to include the corresponding library
+  "satysfi-class-exdesign" {= "%{version}%"}
+]
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "class-exdesign-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-exdesign-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]

--- a/satysfi-class-exdesign.opam
+++ b/satysfi-class-exdesign.opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-name: "exdesign"
-version: "0.2+satysfi0.0.3+satyrograhos0.1.5"
-synopsis: "A class file easy to customize with SATySFi."
+name: "satysfi-class-exdesign"
+version: "0.2"
+synopsis: "A class file easy to customize with SATySFi"
 description: """A class file easy to customize with SATySFi."""
 
 maintainer: "Naoki Kaneko <puripuri2100@gmail.com>"
@@ -13,12 +13,12 @@ dev-repo: "git+https://github.com/puripuri2100/exdesign.git"
 
 depends: [
   "satysfi" {>= "0.0.3" & < "0.0.4"}
-  "satyrographos" {>= "0.0.1" & < "0.0.2"}
+  "satyrographos" {>= "0.0.2" & < "0.0.3"}
 ]
-build: [
-  ["install" "-d" "%share%/satysfi/exdesign/packages"]
-  ["install" "-m" "644" "exdesign.satyh" "article-ja.satyh" "%share%/satysfi/exdesign/packages"]
+build: [ ]
+install: [
+  ["satyrographos" "opam" "install"
+   "-name" "class-exdesign"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
 ]
-
-install: [ ]
-remove: [ ]


### PR DESCRIPTION
This change includes:

- Update to Satyrographos 0.0.2 format
- Move paths from `exdesign` and `article-ja` to `class-exdesign/exdesign` and `class-exdesign/article-ja`, respectively. Although, placing both files at ~/.satysfi/dist/packages must work too.